### PR TITLE
add paging and search on category

### DIFF
--- a/QPCore/Controllers/TestFlowCategoriesController.cs
+++ b/QPCore/Controllers/TestFlowCategoriesController.cs
@@ -147,6 +147,21 @@ namespace QPCore.Controllers
         }
 
         /// <summary>
+        /// Get category by type
+        /// </summary>
+        /// <param name="type"></param>
+        /// <param name="keyword"></param>
+        /// <param name="skip"></param>
+        /// <param name="limit"></param>
+        /// <returns></returns>
+        [HttpGet("search")]
+        public ActionResult<List<TestFlowCategoryResponse>> GetByType(string type, string keyword, int skip = 0, int limit = 20)
+        {
+            var dataItems = _testFlowCategoryService.GetByType(type, keyword, skip, limit);
+            return Ok(dataItems);
+        }
+
+        /// <summary>
         /// Delete category
         /// </summary>
         /// <param name="categoryId"></param>

--- a/QPCore/Model/Common/PaginationResponse.cs
+++ b/QPCore/Model/Common/PaginationResponse.cs
@@ -1,0 +1,14 @@
+using System.Collections.Generic;
+
+namespace QPCore.Model.Common
+{
+    public class PaginationResponse<T> where T : class
+    {
+        public PaginationResponse()
+        {
+            this.Items = new List<T>();
+        }
+        public List<T> Items { get; set; }
+        public int Total { get; set; }
+    }
+}

--- a/QPCore/Service/Interfaces/ITestFlowCategoryService.cs
+++ b/QPCore/Service/Interfaces/ITestFlowCategoryService.cs
@@ -20,6 +20,15 @@ namespace QPCore.Service.Interfaces
         /// <returns></returns>
         List<TestFlowCategoryResponse> GetByClientId(int clientId);
 
+        /// Get category by type
+        /// </summary>
+        /// <param name="type"></param>
+        /// <param name="keyword"></param>
+        /// <param name="skip"></param>
+        /// <param name="limit"></param>
+        /// <returns></returns>
+        PaginationResponse<TestFlowCategoryResponse> GetByType(string type, string keyword, int skip, int limit);
+
         /// <summary>
         /// Get category by id
         /// </summary>

--- a/QPCore/Service/TestFlowCategoryService.cs
+++ b/QPCore/Service/TestFlowCategoryService.cs
@@ -62,13 +62,13 @@ namespace QPCore.Service
             dataItem.UpdatedDate = DateTime.Now;
 
             var dateItem = await _repository.AddAsync(dataItem);
-            
+
             return GetById(dataItem.CategoryId);
         }
 
         public async Task Delete(int categoryId)
         {
-           await _repository.DeleteAsync(categoryId);
+            await _repository.DeleteAsync(categoryId);
         }
 
         public List<TestFlowCategoryResponse> GetAll()
@@ -117,6 +117,30 @@ namespace QPCore.Service
             }
 
             return null;
+        }
+
+        public PaginationResponse<TestFlowCategoryResponse> GetByType(string type, string keyword, int skip, int limit)
+        {
+            keyword = string.IsNullOrWhiteSpace(keyword)? string.Empty : keyword.Trim().ToLower();
+
+            var query = _repository.GetQuery()
+                    .Where(p => p.Type == type && (string.IsNullOrWhiteSpace(keyword) || p.CategoryName.ToLower().Contains(keyword)))
+                    .OrderByDescending(p => p.CategoryName)
+                    .ProjectTo<TestFlowCategoryResponse>(_mapper.ConfigurationProvider);
+            
+            var total = query.Count();
+            var items = query
+                    .Skip(skip)
+                    .Take(limit)
+                    .ToList();
+
+            var result = new PaginationResponse<TestFlowCategoryResponse>()
+            {
+                Items = items,
+                Total = total
+            };
+
+            return result;
         }
     }
 }


### PR DESCRIPTION
GET: api/testflowcategories/search?type=Category&keyword=&skip=0&limit=2

{
    "items": [
        {
            "applicationName": "Test App",
            "categoryId": 7,
            "isActive": false,
            "categoryName": "Temp 345",
            "type": "Area",
            "clientId": 1
        },
        {
            "applicationName": "Test App",
            "categoryId": 9,
            "isActive": true,
            "categoryName": "Temp 30043",
            "type": "Area",
            "clientId": 1
        }
    ],
    "total": 2
}